### PR TITLE
changed the test descriptions for the get_english_meaning method in the spec

### DIFF
--- a/spec/translator_spec.rb
+++ b/spec/translator_spec.rb
@@ -105,15 +105,15 @@ describe "#get_english_meaning" do
     answer = get_english_meaning("./lib/emoticons.yml", "=D")
   end
 
-  it "returns the Japanese equivalent of an English grinning" do
+  it "returns the English meaning of the Japanese emoticon (＾ｖ＾)" do
     expect(get_english_meaning("./lib/emoticons.yml", "(＾ｖ＾)")).to eq("happy")
   end
 
-  it "returns the Japanese equivalent of an English happy" do
+  it "returns the English meaning of the Japanese emoticon (￣ー￣)" do
     expect(get_english_meaning("./lib/emoticons.yml", "(￣ー￣)")).to eq("grinning")
   end
 
-  it "returns the Japanese equivalent of an English sad" do
+  it "returns the English meaning of the Japanese emoticon (Ｔ▽Ｔ)" do
     expect(get_english_meaning("./lib/emoticons.yml", "(Ｔ▽Ｔ)")).to eq("sad")
   end
 


### PR DESCRIPTION
The test descriptions for the get_english_meaning method were the same as for the get_japanese_emoticon method, likely as the result of an unfinished copy/pase edit. I updated them to accurately reflect the tests they're describing. 
